### PR TITLE
! upgrade to kamon 0.6.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtprotobuf.ProtobufPlugin
 
 val akkaVersion = "2.3.14"
 val sprayVersion = "1.3.3"
-val kamonVersion = "0.5.2"
+val kamonVersion = "0.6.2"
 
 lazy val commonSettings = Seq(
   homepage := Some(url("https://monsantoco.github.io/kamon-prometheus")),
@@ -62,6 +62,7 @@ lazy val library = (project in file("library"))
     libraryDependencies ++= Seq(
       "io.kamon"               %% "kamon-core"               % kamonVersion,
       "io.spray"               %% "spray-routing"            % sprayVersion,
+      "io.spray"               %% "spray-can"            % sprayVersion,
       "com.typesafe.akka"      %% "akka-actor"               % akkaVersion,
       "com.typesafe"            % "config"                   % "1.3.0",
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4" % "provided",
@@ -70,7 +71,9 @@ lazy val library = (project in file("library"))
       "com.typesafe.akka" %% "akka-testkit"  % akkaVersion  % "test",
       "io.spray"          %% "spray-testkit" % sprayVersion % "test",
       "org.scalacheck"    %% "scalacheck"    % "1.12.5"     % "test",
-      "io.kamon"          %% "kamon-akka"    % kamonVersion % "test"
+      "io.kamon"          %% "kamon-akka"    % kamonVersion % "test",
+      "ch.qos.logback" % "logback-core" % "1.1.7" % Test,
+      "ch.qos.logback" % "logback-classic" % "1.1.7" % Test
     ),
     dependencyOverrides ++= Set(
       "org.scala-lang"          % "scala-library" % scalaVersion.value,
@@ -82,7 +85,8 @@ lazy val library = (project in file("library"))
     // We have to ensure that Kamon starts/stops serially
     parallelExecution in Test := false,
     // Don't count Protobuf-generated code in coverage
-    coverageExcludedPackages := "com\\.monsanto\\.arch\\.kamon\\.prometheus\\.metric\\..*"
+    coverageExcludedPackages := "com\\.monsanto\\.arch\\.kamon\\.prometheus\\.metric\\..*",
+    javaOptions in Test := Seq("-Xmx2g")
   )
 
 lazy val demo = (project in file("demo"))

--- a/demo/src/main/resources/application.conf
+++ b/demo/src/main/resources/application.conf
@@ -26,6 +26,11 @@ kamon {
   }
 
   prometheus {
+    bind {
+      enabled = true
+      port = 9090
+      interface = "0.0.0.0"
+    }
     refresh-interval = 15 seconds
   }
 }

--- a/demo/src/main/scala/com/monsanto/arch/kamon/prometheus/demo/DemoServiceActor.scala
+++ b/demo/src/main/scala/com/monsanto/arch/kamon/prometheus/demo/DemoServiceActor.scala
@@ -1,21 +1,20 @@
 package com.monsanto.arch.kamon.prometheus.demo
 
-import com.monsanto.arch.kamon.prometheus.Prometheus
 import com.monsanto.arch.kamon.spray.routing.TracingHttpServiceActor
 import kamon.Kamon
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
-/** A simple spray service that contains a simple endpoint and a metrics endpoint that Prometheus can consume.
-  *
+/** A simple spray service that contains a simple endpoint.
+  * Prometheus metrics endpoint is automatically bound to :9090/metrics
   * @author Daniel Solano Gómez
   */
 class DemoServiceActor extends TracingHttpServiceActor {
   import DemoServiceActor._
 
   override implicit val actorRefFactory = context
-  override def receive = runRoute(metricsRoute ~ demoRoute ~ metricRoutes ~ timesOutRoute ~ errorRoute)
+  override def receive = runRoute(demoRoute ~ metricRoutes ~ timesOutRoute ~ errorRoute)
   var minMaxCount = 0L
 
   /** A simple endpoint for `/` which also gives all traces that end up here the name ‘demo-endpoint’. */
@@ -23,7 +22,7 @@ class DemoServiceActor extends TracingHttpServiceActor {
     path("") {
       get {
         complete {
-          "Welcome to the demo for Kamon/Prometheus."
+          "Welcome to the demo for Kamon/Prometheus. See port 9090/metrics for the prometheus metrics endpoint."
         }
       }
     }
@@ -49,7 +48,7 @@ class DemoServiceActor extends TracingHttpServiceActor {
 
           mmc.increment(change)
 
-          minMaxCount.toString
+          minMaxCount.toString()
         }
       } ~
       path("histogram") {
@@ -58,7 +57,7 @@ class DemoServiceActor extends TracingHttpServiceActor {
           val value = System.currentTimeMillis() % 1000L
           h.record(value)
 
-          value.toString
+          value.toString()
         }
       }
     }
@@ -88,11 +87,6 @@ class DemoServiceActor extends TracingHttpServiceActor {
       }
     }
 
-  /** This directive creates the metrics endpoint at `/metrics` and names all traces which end up here ‘metrics’. */
-  val metricsRoute =
-    path("metrics") {
-      Kamon(Prometheus).route
-    }
 }
 
 object DemoServiceActor {

--- a/library/src/main/resources/reference.conf
+++ b/library/src/main/resources/reference.conf
@@ -36,13 +36,21 @@ kamon {
     # guidelines.
     labels {
     }
+
+    # Automatic bind settings for the metrics API
+    bind {
+      enabled = false
+      port = 9090
+      interface = "0.0.0.0"
+      timeout = 30 seconds
+    }
   }
 
   modules {
     monsanto-kamon-prometheus {
       auto-start = yes
       requires-aspectj = no
-      extension-id = "com.monsanto.arch.kamon.prometheus.Prometheus"
+      extension-class = "com.monsanto.arch.kamon.prometheus.Prometheus"
     }
   }
 }

--- a/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusExtension.scala
+++ b/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusExtension.scala
@@ -1,20 +1,29 @@
 package com.monsanto.arch.kamon.prometheus
 
-import akka.actor.ExtendedActorSystem
+import java.util.UUID
+
+import akka.actor.{ActorSystem, Props}
 import akka.event.Logging
+import akka.io.IO
+import akka.pattern.ask
+import akka.util.Timeout
 import kamon.Kamon
 import kamon.metric.TickMetricSnapshotBuffer
+import spray.can.Http
+import spray.can.Http.{Bind, Bound}
 import spray.routing.Route
+
+import scala.util.{Failure, Success}
+import scala.util.control.NonFatal
 
 /** A Kamon extension that provides a Spray endpoint so that Prometheus can retrieve metrics from Kamon.
   *
   * TODO: add real documentation
   *
   * @param system the Actor system to which this class acts as an extension
-  *
   * @author Daniel Solano Gómez
   */
-class PrometheusExtension(system: ExtendedActorSystem) extends Kamon.Extension {
+class PrometheusExtension(system: ActorSystem) extends Kamon.Extension {
   /** Handy log reference. */
   private val log = Logging(system, classOf[PrometheusExtension])
   private val config = system.settings.config
@@ -28,13 +37,13 @@ class PrometheusExtension(system: ExtendedActorSystem) extends Kamon.Extension {
   val isBuffered: Boolean = settings.refreshInterval > Kamon.metrics.settings.tickInterval
 
   /** Manages the Spray endpoint. */
-  private val endpoint = new PrometheusEndpoint(settings)(system)
+  val endpoint = PrometheusEndpoint(system, settings)
   /** Listens to and records metrics. */
-  private[prometheus] val listener = system.actorOf(PrometheusListener.props(endpoint), "prometheus-listener")
+  private[prometheus] val listener = system.actorOf(PrometheusListener.props(endpoint), "prometheus-listener" + UUID.randomUUID().toString)
   /** If the listener needs to listen less frequently than ticks, set up a buffer. */
   private[prometheus] val buffer = {
     if (isBuffered) {
-      system.actorOf(TickMetricSnapshotBuffer.props(settings.refreshInterval, listener), "prometheus-buffer")
+      system.actorOf(TickMetricSnapshotBuffer.props(settings.refreshInterval, listener), "prometheus-buffer" + UUID.randomUUID().toString)
     } else {
       listener
     }
@@ -44,9 +53,26 @@ class PrometheusExtension(system: ExtendedActorSystem) extends Kamon.Extension {
   val route: Route = endpoint.route
 
   log.info("Starting the Kamon(Prometheus) extension")
-  settings.subscriptions.foreach {case (category, selections) ⇒
+  settings.subscriptions.foreach { case (category, selections) ⇒
     selections.foreach { selection ⇒
       Kamon.metrics.subscribe(category, selection, buffer, permanently = true)
     }
+  }
+
+  if (settings.bindEnabled) {
+    implicit val bindTimeout = Timeout(settings.bindTimeout)
+    implicit val sys = system
+    implicit val ec = system.dispatcher
+    log.info(s"Attempting to bind Kamon Prometheus endpoint to ${settings.bindInterface}:${settings.bindPort}")
+    val serviceActor = system.actorOf(Props(classOf[PrometheusService], settings, endpoint))
+    val bindResult = IO(Http) ? Bind(serviceActor, settings.bindInterface, settings.bindPort)
+    bindResult.onComplete {
+      case Success(_: Bound) => log.info(s"Successfully bound prometheus metrics API to ${settings.bindInterface}:${settings.bindPort}")
+      case Success(other) => log.warning(s"Failed to bind prometheus metrics API to ${settings.bindInterface}:${settings.bindPort}. " +
+        s"Expected Bound message, got $other")
+      case Failure(NonFatal(e)) => log.error(e, s"Failed to bind to ${settings.bindInterface}:${settings.bindPort} within configured timeout of ${settings.bindTimeout}")
+    }
+  } else {
+    log.warning("Metrics API binding is disabled, Prometheus Metrics API will not be available")
   }
 }

--- a/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusSettings.scala
+++ b/library/src/main/scala/com/monsanto/arch/kamon/prometheus/PrometheusSettings.scala
@@ -6,7 +6,8 @@ import kamon.Kamon
 import kamon.util.ConfigTools.Syntax
 
 import scala.collection.JavaConversions
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+import scala.util.Try
 
 /** A settings object used for configuring how the extension should behave.
   *
@@ -37,6 +38,11 @@ class PrometheusSettings(config: Config) {
     val labelsConfig = prometheusConfig.getConfig("labels")
     labelsConfig.firstLevelKeys.map(name ⇒ name → labelsConfig.getString(name)).toMap
   }
+
+  val bindEnabled = Try(prometheusConfig.getBoolean("bind.enabled")).getOrElse(false)
+  val bindInterface = Try(prometheusConfig.getString("bind.interface")).getOrElse("0.0.0.0")
+  val bindPort = Try(prometheusConfig.getInt("bind.port")).getOrElse(9090)
+  val bindTimeout = Try(prometheusConfig.getFiniteDuration("bind.timeout")).getOrElse(30.seconds)
 
   // ensure that the refresh interval is not less than the tick interval
   if (refreshInterval < Kamon.metrics.settings.tickInterval) {

--- a/library/src/test/resources/application.conf
+++ b/library/src/test/resources/application.conf
@@ -1,0 +1,40 @@
+kamon {
+  metric {
+    tick-interval = 1 hour
+    default-instrument-settings {
+      gauge.refresh-interval = 1 hour
+      min-max-counter.refresh-interval = 1 hour
+    }
+  }
+
+
+  internal-config.akka {
+    loglevel = "OFF"
+    stdout-loglevel = "OFF"
+    log-dead-letters = off
+
+    actor.default-dispatcher {
+      type = "akka.testkit.CallingThreadDispatcherConfigurator"
+    }
+  }
+  prometheus {
+    refresh-interval = 1 hour
+    subscriptions {
+      histogram = ["**"]
+      min-max-counter = ["**"]
+      gauge = ["**"]
+      counter = ["**"]
+      trace = ["**"]
+      trace-segment = ["**"]
+      akka-actor = ["**"]
+      akka-dispatcher = ["**"]
+      akka-router = ["**"]
+      system-metric = ["**"]
+      http-server = ["**"]
+      spray-can-server = ["**"]
+    }
+    labels {
+    }
+  }
+
+}

--- a/library/src/test/resources/autobind.conf
+++ b/library/src/test/resources/autobind.conf
@@ -1,0 +1,11 @@
+include "application.conf"
+
+kamon {
+  prometheus {
+    bind {
+      enabled = true
+      port = 9091
+      interface = "0.0.0.0"
+    }
+  }
+}

--- a/library/src/test/resources/logback-test.xml
+++ b/library/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- See http://logback.qos.ch/manual/layouts.html -->
+            <!-- See http://doc.akka.io/docs/akka/2.0/scala/logging.html -->
+            <pattern>%date{ISO8601} %-5level %logger{36} %X{sourceThread} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>
+

--- a/library/src/test/scala/com/monsanto/arch/kamon/prometheus/MasterSuite.scala
+++ b/library/src/test/scala/com/monsanto/arch/kamon/prometheus/MasterSuite.scala
@@ -1,0 +1,14 @@
+package com.monsanto.arch.kamon.prometheus
+
+import com.monsanto.arch.kamon.prometheus.converter.SnapshotConverterSpec
+import com.monsanto.arch.kamon.prometheus.metric.{MetricValueSpec, ProtoBufFormatSpec, TextFormatSpec}
+import kamon.Kamon
+import org.scalatest.{BeforeAndAfterAll, Suites}
+
+class MasterSuite extends Suites(
+  new PrometheusExtensionSpec, new SnapshotConverterSpec) with BeforeAndAfterAll {
+
+  override def beforeAll() = Kamon.start()
+  override def afterAll() = Kamon.shutdown()
+
+}

--- a/library/src/test/scala/com/monsanto/arch/kamon/prometheus/converter/SnapshotConverterSpec.scala
+++ b/library/src/test/scala/com/monsanto/arch/kamon/prometheus/converter/SnapshotConverterSpec.scala
@@ -16,11 +16,12 @@ import kamon.metric.instrument.{InstrumentFactory, Memory, Time, UnitOfMeasureme
 import kamon.util.executors.{ForkJoinPoolMetrics, ThreadPoolExecutorMetrics}
 import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{LoneElement, Matchers, WordSpec}
+import org.scalatest.{DoNotDiscover, LoneElement, Matchers, WordSpec}
 
 import scala.concurrent.forkjoin.ForkJoinPool
 
 /** Tests for the conversion of Kamon TickMetricSnapshot instances into our own MetricFamily instances. */
+@DoNotDiscover
 class SnapshotConverterSpec extends WordSpec with KamonTestKit with Matchers with GeneratorDrivenPropertyChecks with LoneElement {
   def handle = afterWord("handle")
 
@@ -28,7 +29,7 @@ class SnapshotConverterSpec extends WordSpec with KamonTestKit with Matchers wit
 
   def are = afterWord("are")
 
-  def converter = new SnapshotConverter(Kamon(Prometheus).settings)
+  def converter = new SnapshotConverter(new PrometheusSettings(ConfigFactory.load()))
 
   "a snapshot converter" should handle {
     "empty ticks" in {
@@ -123,94 +124,94 @@ class SnapshotConverterSpec extends WordSpec with KamonTestKit with Matchers wit
         import SnapshotConverterSpec.{Celsius, Joules}
 
         "unknown" in {
-          val entity = counter("counter", 20, unitOfMeasurement = UnitOfMeasurement.Unknown)
+          val entity = counter(20, unitOfMeasurement = UnitOfMeasurement.Unknown)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter"
+          result.loneElement.name shouldBe entity.name
         }
 
         "nanoseconds" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Time.Nanoseconds)
+          val entity = counter(20, unitOfMeasurement = Time.Nanoseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_nanoseconds"
+          result.loneElement.name should endWith("_nanoseconds")
         }
 
         "microseconds" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Time.Microseconds)
+          val entity = counter(20, unitOfMeasurement = Time.Microseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_microseconds"
+          result.loneElement.name should endWith("_microseconds")
         }
 
         "milliseconds" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Time.Milliseconds)
+          val entity = counter(20, unitOfMeasurement = Time.Milliseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_milliseconds"
+          result.loneElement.name should endWith("_milliseconds")
         }
 
         "seconds" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Time.Seconds)
+          val entity = counter(20, unitOfMeasurement = Time.Seconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_seconds"
+          result.loneElement.name should endWith("_seconds")
         }
 
         "bytes" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Memory.Bytes)
+          val entity = counter(20, unitOfMeasurement = Memory.Bytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_bytes"
+          result.loneElement.name should endWith("_bytes")
         }
 
         "kilobytes" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Memory.KiloBytes)
+          val entity = counter(20, unitOfMeasurement = Memory.KiloBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_kilobytes"
+          result.loneElement.name should endWith("_kilobytes")
         }
 
         "megabytes" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Memory.MegaBytes)
+          val entity = counter(20, unitOfMeasurement = Memory.MegaBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_megabytes"
+          result.loneElement.name should endWith("_megabytes")
         }
 
         "gigabytes" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Memory.GigaBytes)
+          val entity = counter(20, unitOfMeasurement = Memory.GigaBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_gigabytes"
+          result.loneElement.name should endWith("_gigabytes")
         }
 
         "hours (custom time type)" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Time(3600, "h"))
+          val entity = counter(20, unitOfMeasurement = Time(3600, "h"))
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_h"
+          result.loneElement.name should endWith("_h")
         }
 
         "terabytes (custom memory type)" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Time(1024E4, "Tb"))
+          val entity = counter(20, unitOfMeasurement = Time(1024E4, "Tb"))
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_Tb"
+          result.loneElement.name should endWith("_Tb")
         }
 
         "joules (custom type)" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Joules)
+          val entity = counter(20, unitOfMeasurement = Joules)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter_J"
+          result.loneElement.name should endWith("_J")
         }
 
         "celsius (mungeable custom type)" in {
-          val entity = counter("counter", 20, unitOfMeasurement = Celsius)
+          val entity = counter(20, unitOfMeasurement = Celsius)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "counter__C"
+          result.loneElement.name should endWith("__C")
         }
       }
     }
@@ -337,94 +338,94 @@ class SnapshotConverterSpec extends WordSpec with KamonTestKit with Matchers wit
         import SnapshotConverterSpec.{Celsius, Joules}
 
         "unknown" in {
-          val entity = histogram("histogram", unitOfMeasurement = UnitOfMeasurement.Unknown)
+          val entity = histogram(unitOfMeasurement = UnitOfMeasurement.Unknown)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram"
+          result.loneElement.name shouldBe entity.name
         }
 
         "nanoseconds" in {
-          val entity = histogram("histogram", unitOfMeasurement = Time.Nanoseconds)
+          val entity = histogram(unitOfMeasurement = Time.Nanoseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_nanoseconds"
+          result.loneElement.name should endWith("_nanoseconds")
         }
 
         "microseconds" in {
-          val entity = histogram("histogram", unitOfMeasurement = Time.Microseconds)
+          val entity = histogram(unitOfMeasurement = Time.Microseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_microseconds"
+          result.loneElement.name should endWith("_microseconds")
         }
 
         "milliseconds" in {
-          val entity = histogram("histogram", unitOfMeasurement = Time.Milliseconds)
+          val entity = histogram(unitOfMeasurement = Time.Milliseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_milliseconds"
+          result.loneElement.name should endWith("_milliseconds")
         }
 
         "seconds" in {
-          val entity = histogram("histogram", unitOfMeasurement = Time.Seconds)
+          val entity = histogram(unitOfMeasurement = Time.Seconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_seconds"
+          result.loneElement.name should endWith("_seconds")
         }
 
         "bytes" in {
-          val entity = histogram("histogram", unitOfMeasurement = Memory.Bytes)
+          val entity = histogram(unitOfMeasurement = Memory.Bytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_bytes"
+          result.loneElement.name should endWith("_bytes")
         }
 
         "kilobytes" in {
-          val entity = histogram("histogram", unitOfMeasurement = Memory.KiloBytes)
+          val entity = histogram(unitOfMeasurement = Memory.KiloBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_kilobytes"
+          result.loneElement.name should endWith("_kilobytes")
         }
 
         "megabytes" in {
-          val entity = histogram("histogram", unitOfMeasurement = Memory.MegaBytes)
+          val entity = histogram(unitOfMeasurement = Memory.MegaBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_megabytes"
+          result.loneElement.name should endWith("_megabytes")
         }
 
         "gigabytes" in {
-          val entity = histogram("histogram", unitOfMeasurement = Memory.GigaBytes)
+          val entity = histogram(unitOfMeasurement = Memory.GigaBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_gigabytes"
+          result.loneElement.name should endWith("_gigabytes")
         }
 
         "hours (custom time type)" in {
-          val entity = histogram("histogram", unitOfMeasurement = Time(3600, "h"))
+          val entity = histogram(unitOfMeasurement = Time(3600, "h"))
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_h"
+          result.loneElement.name should endWith("_h")
         }
 
         "terabytes (custom memory type)" in {
-          val entity = histogram("histogram", unitOfMeasurement = Time(1024E4, "Tb"))
+          val entity = histogram(unitOfMeasurement = Time(1024E4, "Tb"))
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_Tb"
+          result.loneElement.name should endWith("_Tb")
         }
 
         "joules (custom type)" in {
-          val entity = histogram("histogram", unitOfMeasurement = Joules)
+          val entity = histogram(unitOfMeasurement = Joules)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram_J"
+          result.loneElement.name should endWith("_J")
         }
 
         "celsius (mungeable custom type)" in {
-          val entity = histogram("histogram", unitOfMeasurement = Celsius)
+          val entity = histogram(unitOfMeasurement = Celsius)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "histogram__C"
+          result.loneElement.name should endWith("__C")
         }
       }
     }
@@ -529,94 +530,94 @@ class SnapshotConverterSpec extends WordSpec with KamonTestKit with Matchers wit
         import SnapshotConverterSpec.{Celsius, Joules}
 
         "unknown" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = UnitOfMeasurement.Unknown)
+          val entity = minMaxCounter(unitOfMeasurement = UnitOfMeasurement.Unknown)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter"
+          result.loneElement.name shouldBe entity.name
         }
 
         "nanoseconds" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Time.Nanoseconds)
+          val entity = minMaxCounter(unitOfMeasurement = Time.Nanoseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_nanoseconds"
+          result.loneElement.name should endWith("_nanoseconds")
         }
 
         "microseconds" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Time.Microseconds)
+          val entity = minMaxCounter(unitOfMeasurement = Time.Microseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_microseconds"
+          result.loneElement.name should endWith("_microseconds")
         }
 
         "milliseconds" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Time.Milliseconds)
+          val entity = minMaxCounter(unitOfMeasurement = Time.Milliseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_milliseconds"
+          result.loneElement.name should endWith("_milliseconds")
         }
 
         "seconds" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Time.Seconds)
+          val entity = minMaxCounter(unitOfMeasurement = Time.Seconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_seconds"
+          result.loneElement.name should endWith("_seconds")
         }
 
         "bytes" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Memory.Bytes)
+          val entity = minMaxCounter(unitOfMeasurement = Memory.Bytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_bytes"
+          result.loneElement.name should endWith("_bytes")
         }
 
         "kilobytes" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Memory.KiloBytes)
+          val entity = minMaxCounter(unitOfMeasurement = Memory.KiloBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_kilobytes"
+          result.loneElement.name should endWith("_kilobytes")
         }
 
         "megabytes" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Memory.MegaBytes)
+          val entity = minMaxCounter(unitOfMeasurement = Memory.MegaBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_megabytes"
+          result.loneElement.name should endWith("_megabytes")
         }
 
         "gigabytes" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Memory.GigaBytes)
+          val entity = minMaxCounter(unitOfMeasurement = Memory.GigaBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_gigabytes"
+          result.loneElement.name should endWith("_gigabytes")
         }
 
         "hours (custom time type)" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Time(3600, "h"))
+          val entity = minMaxCounter(unitOfMeasurement = Time(3600, "h"))
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_h"
+          result.loneElement.name should endWith("_h")
         }
 
         "terabytes (custom memory type)" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Time(1024E4, "Tb"))
+          val entity = minMaxCounter(unitOfMeasurement = Time(1024E4, "Tb"))
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_Tb"
+          result.loneElement.name should endWith("_Tb")
         }
 
         "joules (custom type)" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Joules)
+          val entity = minMaxCounter(unitOfMeasurement = Joules)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter_J"
+          result.loneElement.name should endWith("_J")
         }
 
         "celsius (mungeable custom type)" in {
-          val entity = minMaxCounter("minMaxCounter", unitOfMeasurement = Celsius)
+          val entity = minMaxCounter(unitOfMeasurement = Celsius)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "minMaxCounter__C"
+          result.loneElement.name should endWith("__C")
         }
       }
     }
@@ -728,94 +729,94 @@ class SnapshotConverterSpec extends WordSpec with KamonTestKit with Matchers wit
         import SnapshotConverterSpec.{Celsius, Joules}
 
         "unknown" in {
-          val entity = gauge("gauge", unitOfMeasurement = UnitOfMeasurement.Unknown)
+          val entity = gauge(unitOfMeasurement = UnitOfMeasurement.Unknown)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge"
+          result.loneElement.name shouldBe entity.name
         }
 
         "nanoseconds" in {
-          val entity = gauge("gauge", unitOfMeasurement = Time.Nanoseconds)
+          val entity = gauge(unitOfMeasurement = Time.Nanoseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_nanoseconds"
+          result.loneElement.name should endWith("_nanoseconds")
         }
 
         "microseconds" in {
-          val entity = gauge("gauge", unitOfMeasurement = Time.Microseconds)
+          val entity = gauge(unitOfMeasurement = Time.Microseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_microseconds"
+          result.loneElement.name should endWith("_microseconds")
         }
 
         "milliseconds" in {
-          val entity = gauge("gauge", unitOfMeasurement = Time.Milliseconds)
+          val entity = gauge(unitOfMeasurement = Time.Milliseconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_milliseconds"
+          result.loneElement.name should endWith("_milliseconds")
         }
 
         "seconds" in {
-          val entity = gauge("gauge", unitOfMeasurement = Time.Seconds)
+          val entity = gauge(unitOfMeasurement = Time.Seconds)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_seconds"
+          result.loneElement.name should endWith("_seconds")
         }
 
         "bytes" in {
-          val entity = gauge("gauge", unitOfMeasurement = Memory.Bytes)
+          val entity = gauge(unitOfMeasurement = Memory.Bytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_bytes"
+          result.loneElement.name should endWith("_bytes")
         }
 
         "kilobytes" in {
-          val entity = gauge("gauge", unitOfMeasurement = Memory.KiloBytes)
+          val entity = gauge(unitOfMeasurement = Memory.KiloBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_kilobytes"
+          result.loneElement.name should endWith("_kilobytes")
         }
 
         "megabytes" in {
-          val entity = gauge("gauge", unitOfMeasurement = Memory.MegaBytes)
+          val entity = gauge(unitOfMeasurement = Memory.MegaBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_megabytes"
+          result.loneElement.name should endWith("_megabytes")
         }
 
         "gigabytes" in {
-          val entity = gauge("gauge", unitOfMeasurement = Memory.GigaBytes)
+          val entity = gauge(unitOfMeasurement = Memory.GigaBytes)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_gigabytes"
+          result.loneElement.name should endWith("_gigabytes")
         }
 
         "hours (custom time type)" in {
-          val entity = gauge("gauge", unitOfMeasurement = Time(3600, "h"))
+          val entity = gauge(unitOfMeasurement = Time(3600, "h"))
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_h"
+          result.loneElement.name should endWith("_h")
         }
 
         "terabytes (custom memory type)" in {
-          val entity = gauge("gauge", unitOfMeasurement = Time(1024E4, "Tb"))
+          val entity = gauge(unitOfMeasurement = Time(1024E4, "Tb"))
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_Tb"
+          result.loneElement.name should endWith("_Tb")
         }
 
         "joules (custom type)" in {
-          val entity = gauge("gauge", unitOfMeasurement = Joules)
+          val entity = gauge(unitOfMeasurement = Joules)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge_J"
+          result.loneElement.name should endWith("_J")
         }
 
         "celsius (mungeable custom type)" in {
-          val entity = gauge("gauge", unitOfMeasurement = Celsius)
+          val entity = gauge(unitOfMeasurement = Celsius)
           val tick = snapshotOf(entity)
           val result = converter(tick)
-          result.loneElement.name shouldBe "gauge__C"
+          result.loneElement.name should endWith("__C")
         }
       }
     }
@@ -1375,10 +1376,12 @@ object SnapshotConverterSpec {
   case object Joules extends UnitOfMeasurement {
     override val name = "energy"
     override val label = "J"
+    override protected def canScale(toUnit: UnitOfMeasurement): Boolean = toUnit == this
   }
 
   case object Celsius extends UnitOfMeasurement {
     override val name = "temperature"
     override val label = "°C"
+    override protected def canScale(toUnit: UnitOfMeasurement): Boolean = toUnit == this
   }
 }


### PR DESCRIPTION
notes: 
- Kamon privatised a bunch of stuff so we can not rely on a clean slate during test (hence the addition of nonce to metric names).
- Kamon removed the apply method that takes an extensionId, so we just automatically bind to a port if configured to do so. 
- Demo is broken as it depends on spray-kamon-metrics which has not been updated to the latest kamon version. 